### PR TITLE
feat: implement DailyWord nightly cron job and today endpoint

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -8,6 +8,7 @@ import GameHint from './components/GameHint.vue'
 import GameKeyboard from './components/GameKeyboard.vue'
 import Navbar from './components/Navbar.vue'
 import ThemeToggle from './components/ThemeToggle.vue'
+import ComingSoon from './components/ComingSoon.vue'
 
 import './index.css'
 import 'vue3-toastify/dist/index.css'
@@ -31,5 +32,6 @@ app.component('GameHint', GameHint)
 app.component('GameKeyboard', GameKeyboard)
 app.component('Navbar', Navbar)
 app.component('ThemeToggle', ThemeToggle)
+app.component('ComingSoon', ComingSoon)
 
 app.mount('#app')

--- a/client/src/views/DailyPage.vue
+++ b/client/src/views/DailyPage.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { Calendar } from '@lucide/vue'
-import ComingSoon from '@/components/ComingSoon.vue'
 </script>
 
 <template>

--- a/client/src/views/LeaderboardPage.vue
+++ b/client/src/views/LeaderboardPage.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { Trophy } from '@lucide/vue'
-import ComingSoon from '@/components/ComingSoon.vue'
 </script>
 
 <template>

--- a/client/src/views/VersusPage.vue
+++ b/client/src/views/VersusPage.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { Swords } from '@lucide/vue'
-import ComingSoon from '@/components/ComingSoon.vue'
 </script>
 
 <template>

--- a/wordev-api/src/app.module.ts
+++ b/wordev-api/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { PrismaModule } from './prisma/prisma.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -6,9 +7,10 @@ import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { GamesModule } from './games/games.module';
 import { WordModule } from './word/word.module';
+import { DailyWordModule } from './daily-word/daily-word.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, UsersModule, GamesModule, WordModule],
+  imports: [ScheduleModule.forRoot(), PrismaModule, AuthModule, UsersModule, GamesModule, WordModule, DailyWordModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/wordev-api/src/daily-word/daily-word.controller.spec.ts
+++ b/wordev-api/src/daily-word/daily-word.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DailyWordController } from './daily-word.controller';
+
+describe('DailyWordController', () => {
+  let controller: DailyWordController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DailyWordController],
+    }).compile();
+
+    controller = module.get<DailyWordController>(DailyWordController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/wordev-api/src/daily-word/daily-word.controller.ts
+++ b/wordev-api/src/daily-word/daily-word.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { DailyWordService } from './daily-word.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('daily-word')
+export class DailyWordController {
+  constructor(private readonly dailyWordService: DailyWordService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get('today')
+  getToday() {
+    return this.dailyWordService.getToday();
+  }
+}

--- a/wordev-api/src/daily-word/daily-word.module.ts
+++ b/wordev-api/src/daily-word/daily-word.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DailyWordService } from './daily-word.service';
+import { DailyWordController } from './daily-word.controller';
+
+@Module({
+  providers: [DailyWordService],
+  controllers: [DailyWordController],
+  exports: [DailyWordService],
+})
+export class DailyWordModule {}

--- a/wordev-api/src/daily-word/daily-word.service.spec.ts
+++ b/wordev-api/src/daily-word/daily-word.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DailyWordService } from './daily-word.service';
+
+describe('DailyWordService', () => {
+  let service: DailyWordService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DailyWordService],
+    }).compile();
+
+    service = module.get<DailyWordService>(DailyWordService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/wordev-api/src/daily-word/daily-word.service.ts
+++ b/wordev-api/src/daily-word/daily-word.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, Logger, OnModuleInit, ServiceUnavailableException } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class DailyWordService implements OnModuleInit {
+  private readonly logger = new Logger(DailyWordService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async onModuleInit() {
+    const today = this.todayDate();
+    const existing = await this.prisma.dailyWord.findUnique({ where: { date: today } });
+    if (!existing) {
+      this.logger.log('No daily word found for today on startup — assigning one now.');
+      await this.assignDailyWord();
+    }
+  }
+
+  @Cron('0 0 * * *')
+  async assignDailyWord() {
+    const today = this.todayDate();
+
+    const thirtyDaysAgo = new Date(today);
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    const recent = await this.prisma.dailyWord.findMany({
+      where: { date: { gte: thirtyDaysAgo } },
+      select: { wordId: true },
+    });
+
+    const excludedIds = recent.map((dw) => dw.wordId);
+
+    const count = await this.prisma.word.count({
+      where: { isAnswer: true, id: { notIn: excludedIds } },
+    });
+
+    if (count === 0) {
+      this.logger.error('No eligible words left for daily assignment (all used in the last 30 days).');
+      return;
+    }
+
+    const skip = Math.floor(Math.random() * count);
+    const [word] = await this.prisma.word.findMany({
+      where: { isAnswer: true, id: { notIn: excludedIds } },
+      skip,
+      take: 1,
+    });
+
+    await this.prisma.dailyWord.upsert({
+      where: { date: today },
+      update: { wordId: word.id },
+      create: { date: today, wordId: word.id },
+    });
+
+    this.logger.log(`Daily word for ${today.toISOString().slice(0, 10)}: "${word.word}"`);
+  }
+
+  async getToday() {
+    const today = this.todayDate();
+    const daily = await this.prisma.dailyWord.findUnique({
+      where: { date: today },
+      include: { word: true },
+    });
+
+    if (!daily) {
+      throw new ServiceUnavailableException('No daily word assigned yet for today.');
+    }
+
+    return { date: daily.date, word: daily.word.word, length: daily.word.length };
+  }
+
+  private todayDate(): Date {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+}


### PR DESCRIPTION
- Register ScheduleModule.forRoot() in AppModule
- DailyWordService: assign a random word (not used in 30 days) at midnight via @Cron
- DailyWordService: onModuleInit startup check if no word exists for today
- DailyWordController: GET /daily-word/today behind JwtAuthGuard
- Register ComingSoon component globally in main.ts

CLOSES(#13)