### PR TITLE
feat: implement POST /games/daily/start endpoint

### DIFF
--- a/wordev-api/src/games/games.controller.ts
+++ b/wordev-api/src/games/games.controller.ts
@@ -7,6 +7,12 @@ export class GamesController {
   constructor(private readonly gamesService: GamesService) {}
 
   @UseGuards(JwtAuthGuard)
+  @Post('daily/start')
+  async startDailyGame(@Req() req) {
+    return this.gamesService.startDailyGame(req.user.userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Post('solo/start')
   async startSoloGame(@Req() req, @Body('length') length?: number) {
     const userId = req.user.userId;

--- a/wordev-api/src/games/games.module.ts
+++ b/wordev-api/src/games/games.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { GamesController } from './games.controller';
 import { GamesService } from './games.service';
 import { WordModule } from '../word/word.module';
+import { DailyWordModule } from '../daily-word/daily-word.module';
 
 @Module({
-  imports: [WordModule],
+  imports: [WordModule, DailyWordModule],
   controllers: [GamesController],
   providers: [GamesService]
 })

--- a/wordev-api/src/games/games.service.ts
+++ b/wordev-api/src/games/games.service.ts
@@ -1,10 +1,50 @@
 import { Injectable, InternalServerErrorException, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { WordService } from '../word/word.service';
+import { DailyWordService } from '../daily-word/daily-word.service';
 
 @Injectable()
 export class GamesService {
-    constructor(private prisma: PrismaService, private wordService: WordService) {}
+    constructor(
+        private prisma: PrismaService,
+        private wordService: WordService,
+        private dailyWordService: DailyWordService,
+    ) {}
+
+    async startDailyGame(userId: string) {
+        const startOfDay = new Date();
+        startOfDay.setHours(0, 0, 0, 0);
+
+        const existing = await this.prisma.game.findFirst({
+            where: {
+                player1Id: userId,
+                mode: 'DAILY',
+                startedAt: { gte: startOfDay },
+            },
+        });
+
+        if (existing) {
+            throw new BadRequestException('You have already played today\'s daily challenge');
+        }
+
+        const dailyWord = await this.dailyWordService.getToday();
+
+        const game = await this.prisma.game.create({
+            data: {
+                mode: 'DAILY',
+                status: 'ACTIVE',
+                word: dailyWord.word,
+                player1Id: userId,
+            },
+            select: {
+                id: true,
+                mode: true,
+                status: true,
+            },
+        });
+
+        return { gameId: game.id, mode: game.mode, status: game.status };
+    }
 
     async startSoloGame(userId: string, length?: number) {
         const randomWord = await this.wordService.getRandomWord(length);


### PR DESCRIPTION
## Summary
- Adds `POST /games/daily/start` endpoint protected by `JwtAuthGuard`
- Returns HTTP 400 if the user has already started today's daily challenge
- Fetches today's word from `DailyWord` table and creates a `DAILY` game with status `ACTIVE`
- Returns `{ gameId, mode, status }`

Closes (#14)