### PR TITLE
feat: Daily game - UI and endpoint GET for status

### DIFF
--- a/client/src/stores/game.ts
+++ b/client/src/stores/game.ts
@@ -9,6 +9,7 @@ const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 
 export const useGameStore = defineStore('game', () => {
   const phase = ref<GamePhase>('setup')
+  const mode = ref<'solo' | 'daily'>('solo')
   const selectedLength = ref<number | null>(null)
   const wordLength = ref(5)
   const gameId = ref<string | null>(null)
@@ -21,6 +22,8 @@ export const useGameStore = defineStore('game', () => {
   const isHinting = ref(false)
   const revealedWord = ref<string | null>(null)
   const hints = ref<{ position: number; letter: string }[]>([])
+  const alreadyPlayedData = ref<{ won: boolean; attempts: number } | null>(null)
+  const dailyShareText = ref<string | null>(null)
 
   const letterColors = computed(() => {
     const priority: Record<LetterResult, number> = { correct: 2, present: 1, absent: 0 }
@@ -53,15 +56,74 @@ export const useGameStore = defineStore('game', () => {
   async function startGame() {
     try {
       error.value = ''
-      const body: { length?: number } = {}
-      if (selectedLength.value !== null) body.length = selectedLength.value
-      const res = await api.post('/games/solo/start', body)
-      gameId.value = res.data.id
-      wordLength.value = res.data.wordLength
+      if (mode.value === 'daily') {
+        const res = await api.post('/games/daily/start')
+        gameId.value = res.data.gameId
+        wordLength.value = res.data.wordLength
+      } else {
+        const body: { length?: number } = {}
+        if (selectedLength.value !== null) body.length = selectedLength.value
+        const res = await api.post('/games/solo/start', body)
+        gameId.value = res.data.id
+        wordLength.value = res.data.wordLength
+      }
       reset()
       phase.value = 'playing'
+    } catch (err: any) {
+      error.value = err.response?.data?.message ?? 'Failed to start game. Try again.'
+    }
+  }
+
+  async function checkDailyStatus() {
+    phase.value = 'loading'
+    try {
+      const res = await api.get('/games/daily/today')
+      const data = res.data
+      if (!data.hasPlayed) {
+        phase.value = 'setup'
+        return
+      }
+      if (data.status === 'ACTIVE') {
+        gameId.value = data.gameId
+        wordLength.value = data.wordLength
+        hints.value = (data.hintedPositions as number[]).map((pos: number, i: number) => ({
+          position: pos,
+          letter: data.hintedLetters[i] as string,
+        }))
+        phase.value = 'playing'
+      } else {
+        alreadyPlayedData.value = { won: !!data.winnerId, attempts: data.attempts }
+        const today = new Date().toISOString().slice(0, 10)
+        dailyShareText.value = localStorage.getItem(`wordev-daily-share-${today}`)
+        phase.value = 'already_played'
+      }
     } catch {
-      error.value = 'Failed to start game. Try again.'
+      error.value = 'Could not check daily status.'
+      phase.value = 'setup'
+    }
+  }
+
+  function buildShareText(won: boolean): string {
+    const date = new Date().toISOString().slice(0, 10)
+    const emojiMap: Record<LetterResult, string> = { correct: '🟩', present: '🟨', absent: '⬛' }
+    const grid = guesses.value.map(g => g.result.map(r => emojiMap[r]).join('')).join('\n')
+    return `Wordev Daily ${date}\n${won ? guesses.value.length : 'X'}/6\n\n${grid}`
+  }
+
+  function saveShareText(won: boolean) {
+    const text = buildShareText(won)
+    const date = new Date().toISOString().slice(0, 10)
+    localStorage.setItem(`wordev-daily-share-${date}`, text)
+    dailyShareText.value = text
+  }
+
+  async function shareResult(): Promise<boolean> {
+    if (!dailyShareText.value) return false
+    try {
+      await navigator.clipboard.writeText(dailyShareText.value)
+      return true
+    } catch {
+      return false
     }
   }
 
@@ -101,10 +163,12 @@ export const useGameStore = defineStore('game', () => {
 
       if (isFinished) {
         if (isWon) {
+          if (mode.value === 'daily') saveShareText(true)
           phase.value = 'won'
         } else {
           const statusRes = await api.get(`/games/solo/${gameId.value}`)
           revealedWord.value = statusRes.data.word
+          if (mode.value === 'daily') saveShareText(false)
           phase.value = 'lost'
         }
       }
@@ -140,10 +204,12 @@ export const useGameStore = defineStore('game', () => {
   }
 
   return {
-    phase, selectedLength, wordLength, gameId,
+    phase, mode, selectedLength, wordLength, gameId,
     guesses, revealingGuess, revealedTiles,
     currentInput, error, isSubmitting, revealedWord,
     hints, letterColors, attemptsLeft, hintsLeft, isHinting,
+    alreadyPlayedData, dailyShareText,
     startGame, submitGuess, addLetter, removeLetter, reset, requestHint,
+    checkDailyStatus, shareResult,
   }
 })

--- a/client/src/types/game.ts
+++ b/client/src/types/game.ts
@@ -1,6 +1,6 @@
 export type LetterResult = 'correct' | 'present' | 'absent'
 
-export type GamePhase = 'setup' | 'playing' | 'won' | 'lost'
+export type GamePhase = 'setup' | 'loading' | 'playing' | 'won' | 'lost' | 'already_played'
 
 export interface Guess {
   letters: string[]

--- a/client/src/views/DailyPage.vue
+++ b/client/src/views/DailyPage.vue
@@ -1,17 +1,205 @@
 <script setup lang="ts">
-import { Calendar } from '@lucide/vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { toast } from 'vue3-toastify'
+import { Calendar, Share2, Timer } from '@lucide/vue'
+import { useGameStore } from '@/stores/game'
+
+const game = useGameStore()
+const countdown = ref('')
+let countdownInterval: ReturnType<typeof setInterval> | null = null
+
+const dailyGrid = computed(() => game.dailyShareText?.split('\n\n')[1] ?? null)
+
+function updateCountdown() {
+  const now = new Date()
+  const tomorrow = new Date(now)
+  tomorrow.setUTCHours(24, 0, 0, 0)
+  const diff = tomorrow.getTime() - now.getTime()
+  const h = Math.floor(diff / 3600000)
+  const m = Math.floor((diff % 3600000) / 60000)
+  const s = Math.floor((diff % 60000) / 1000)
+  countdown.value = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+async function share() {
+  const ok = await game.shareResult()
+  if (ok) toast('Result copied to clipboard!', { type: 'success' })
+  else toast('Could not copy to clipboard', { type: 'error' })
+}
+
+watch(() => game.phase, (newPhase, oldPhase) => {
+  if (newPhase === 'playing' && oldPhase === 'setup') {
+    toast('Daily challenge started! One shot — make it count!', { type: 'info' })
+  } else if (newPhase === 'won') {
+    const count = game.guesses.length
+    toast(`Daily word conquered in ${count} ${count === 1 ? 'guess' : 'guesses'}!`, { type: 'success' })
+  } else if (newPhase === 'lost') {
+    toast(`The word was "${game.revealedWord?.toUpperCase()}"`, { type: 'error', autoClose: 5000 })
+  }
+})
+
+onMounted(() => {
+  game.mode = 'daily'
+  game.checkDailyStatus()
+  updateCountdown()
+  countdownInterval = setInterval(updateCountdown, 1000)
+})
+
+onUnmounted(() => {
+  if (countdownInterval) clearInterval(countdownInterval)
+})
 </script>
 
 <template>
-  <main class="flex flex-col items-center justify-center flex-1 px-8 py-12">
-    <div class="w-full max-w-4xl space-y-4">
-      <div class="flex items-center gap-3" :style="{ color: 'var(--color-text-muted)' }">
+  <!-- LOADING -->
+  <main v-if="game.phase === 'loading'" class="flex flex-col items-center justify-center flex-1 px-4 py-12">
+    <div class="flex flex-col items-center gap-4" :style="{ color: 'var(--color-text-muted)' }">
+      <div class="w-8 h-8 border-2 border-current border-t-transparent rounded-full animate-spin" />
+      <span class="text-sm uppercase tracking-widest">Loading...</span>
+    </div>
+  </main>
+
+  <!-- SETUP (hasn't played today) -->
+  <main v-else-if="game.phase === 'setup'" class="flex flex-col items-center justify-center flex-1 px-8 py-12">
+    <div class="w-full max-w-lg space-y-8">
+      <div class="space-y-2">
+        <div
+          v-motion :initial="{ opacity: 0 }" :enter="{ opacity: 1, transition: { duration: 400 } }"
+          class="flex items-center gap-3" :style="{ color: 'var(--color-text-muted)' }"
+        >
+          <Calendar class="w-5 h-5" />
+          <span class="text-sm uppercase tracking-widest">Daily Challenge</span>
+        </div>
+        <h1
+          v-motion :initial="{ opacity: 0, y: 20 }" :enter="{ opacity: 1, y: 0, transition: { duration: 400, delay: 80 } }"
+          class="text-3xl font-bold"
+        >Word of the Day</h1>
+        <p
+          v-motion :initial="{ opacity: 0, y: 16 }" :enter="{ opacity: 1, y: 0, transition: { duration: 400, delay: 160 } }"
+          class="text-sm" :style="{ color: 'var(--color-text-muted)' }"
+        >One shot. Make it count.</p>
+      </div>
+
+      <p v-if="game.error" class="text-sm" :style="{ color: 'var(--color-accent)' }">{{ game.error }}</p>
+
+      <button
+        v-motion :initial="{ opacity: 0 }" :enter="{ opacity: 1, transition: { duration: 400, delay: 240 } }"
+        @click="game.startGame()"
+        class="px-8 py-3 font-bold tracking-widest uppercase text-sm rounded-xs cursor-pointer"
+        :style="{ backgroundColor: 'var(--color-accent)', color: 'var(--color-accent-dark)' }"
+      >Start Daily Challenge</button>
+    </div>
+  </main>
+
+  <!-- ALREADY PLAYED (finished game, returning visit) -->
+  <main v-else-if="game.phase === 'already_played'" class="flex flex-col items-center justify-center flex-1 px-8 py-12">
+    <div class="w-full max-w-sm space-y-6 text-center">
+      <div class="flex items-center justify-center gap-3" :style="{ color: 'var(--color-text-muted)' }">
         <Calendar class="w-5 h-5" />
         <span class="text-sm uppercase tracking-widest">Daily Challenge</span>
       </div>
-      <h1 class="text-4xl font-bold">Word of the Day</h1>
-      <p :style="{ color: 'var(--color-text-muted)' }">One shot. Make it count.</p>
-      <ComingSoon />
+
+      <div v-if="game.alreadyPlayedData" class="space-y-1">
+        <p v-if="game.alreadyPlayedData.won" class="text-xl font-bold" :style="{ color: 'var(--color-correct)' }">
+          You won in {{ game.alreadyPlayedData.attempts }}/6!
+        </p>
+        <p v-else class="text-xl font-bold">
+          Better luck tomorrow — <span :style="{ color: 'var(--color-accent)' }">{{ game.alreadyPlayedData.attempts }}/6</span>
+        </p>
+      </div>
+
+      <pre
+        v-if="dailyGrid"
+        class="text-2xl leading-tight font-mono mx-auto"
+        style="width: fit-content"
+      >{{ dailyGrid }}</pre>
+
+      <button
+        v-if="game.dailyShareText"
+        @click="share()"
+        class="flex items-center gap-2 mx-auto px-6 py-2.5 font-bold tracking-widest uppercase text-sm rounded-xs cursor-pointer"
+        :style="{ backgroundColor: 'var(--color-accent)', color: 'var(--color-accent-dark)' }"
+      >
+        <Share2 class="w-4 h-4" />
+        Share Result
+      </button>
+
+      <div class="flex items-center justify-center gap-2 text-sm" :style="{ color: 'var(--color-text-muted)' }">
+        <Timer class="w-4 h-4" />
+        <span>Next word in <span class="font-mono font-bold">{{ countdown }}</span></span>
+      </div>
     </div>
+  </main>
+
+  <!-- GAME (playing, won, lost) -->
+  <main v-else class="flex flex-col items-center gap-5 px-4 py-6">
+
+    <div class="flex items-center gap-3" :style="{ color: 'var(--color-text-muted)' }">
+      <Calendar class="w-4 h-4" />
+      <span class="text-xs uppercase tracking-widest">Daily Challenge</span>
+    </div>
+
+    <GameGrid
+      :guesses="game.guesses"
+      :revealing-guess="game.revealingGuess"
+      :revealed-tiles="game.revealedTiles"
+      :current-input="game.currentInput"
+      :word-length="game.wordLength"
+      :phase="game.phase"
+    />
+
+    <p class="text-sm" :style="{ color: 'var(--color-text-muted)' }">
+      <template v-if="game.phase === 'playing'">
+        {{ game.attemptsLeft }} attempt{{ game.attemptsLeft === 1 ? '' : 's' }} left
+      </template>
+    </p>
+
+    <GameHint
+      v-if="game.phase === 'playing'"
+      :hints-left="game.hintsLeft"
+      :hints="game.hints"
+      :loading="game.isHinting"
+      @request="game.requestHint()"
+    />
+
+    <p v-if="game.error" class="text-sm" :style="{ color: 'var(--color-accent)' }">{{ game.error }}</p>
+
+    <div
+      v-if="game.phase === 'won' || game.phase === 'lost'"
+      v-motion :initial="{ opacity: 0, y: -10 }" :enter="{ opacity: 1, y: 0, transition: { duration: 300 } }"
+      class="flex flex-col items-center gap-4 text-center"
+    >
+      <p v-if="game.phase === 'won'" class="font-bold text-lg" :style="{ color: 'var(--color-correct)' }">
+        You got it in {{ game.guesses.length }} {{ game.guesses.length === 1 ? 'guess' : 'guesses' }}!
+      </p>
+      <p v-else class="font-bold text-lg">
+        The word was <span :style="{ color: 'var(--color-accent)' }">{{ game.revealedWord }}</span>
+      </p>
+
+      <button
+        v-if="game.dailyShareText"
+        @click="share()"
+        class="flex items-center gap-2 px-6 py-2.5 font-bold tracking-widest uppercase text-sm rounded-xs cursor-pointer"
+        :style="{ backgroundColor: 'var(--color-accent)', color: 'var(--color-accent-dark)' }"
+      >
+        <Share2 class="w-4 h-4" />
+        Share Result
+      </button>
+
+      <div class="flex items-center gap-2 text-sm" :style="{ color: 'var(--color-text-muted)' }">
+        <Timer class="w-4 h-4" />
+        <span>Next word in <span class="font-mono font-bold">{{ countdown }}</span></span>
+      </div>
+    </div>
+
+    <GameKeyboard
+      v-if="game.phase === 'playing'"
+      :letter-colors="game.letterColors"
+      :active="game.phase === 'playing'"
+      @letter="game.addLetter"
+      @submit="game.submitGuess"
+      @backspace="game.removeLetter"
+    />
+
   </main>
 </template>

--- a/client/src/views/SoloPage.vue
+++ b/client/src/views/SoloPage.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
-import { watch } from 'vue'
+import { watch, onMounted } from 'vue'
 import { toast } from 'vue3-toastify'
 import { useGameStore } from '@/stores/game'
 
 const game = useGameStore()
 const LENGTH_OPTIONS = [4, 5, 6, 7, 8, 9, 10]
+
+onMounted(() => {
+  game.mode = 'solo'
+})
 
 watch(() => game.phase, (newPhase, oldPhase) => {
   if (newPhase === 'playing' && oldPhase === 'setup') {

--- a/wordev-api/src/games/games.controller.ts
+++ b/wordev-api/src/games/games.controller.ts
@@ -7,6 +7,12 @@ export class GamesController {
   constructor(private readonly gamesService: GamesService) {}
 
   @UseGuards(JwtAuthGuard)
+  @Get('daily/today')
+  async getDailyStatus(@Req() req) {
+    return this.gamesService.getDailyStatus(req.user.userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Post('daily/start')
   async startDailyGame(@Req() req) {
     return this.gamesService.startDailyGame(req.user.userId);

--- a/wordev-api/src/games/games.service.ts
+++ b/wordev-api/src/games/games.service.ts
@@ -43,7 +43,52 @@ export class GamesService {
             },
         });
 
-        return { gameId: game.id, mode: game.mode, status: game.status };
+        return { gameId: game.id, mode: game.mode, status: game.status, wordLength: dailyWord.length };
+    }
+
+    async getDailyStatus(userId: string) {
+        const startOfDay = new Date();
+        startOfDay.setHours(0, 0, 0, 0);
+
+        const game = await this.prisma.game.findFirst({
+            where: {
+                player1Id: userId,
+                mode: 'DAILY',
+                startedAt: { gte: startOfDay },
+            },
+            select: {
+                id: true,
+                status: true,
+                player1Attempts: true,
+                winnerId: true,
+                hintsUsed: true,
+                hintedPositions: true,
+                word: true,
+            },
+        });
+
+        if (!game) return { hasPlayed: false };
+
+        if (game.status === 'ACTIVE') {
+            return {
+                hasPlayed: true,
+                gameId: game.id,
+                status: 'ACTIVE',
+                attempts: game.player1Attempts,
+                hintsUsed: game.hintsUsed,
+                wordLength: game.word.length,
+                hintedPositions: game.hintedPositions,
+                hintedLetters: game.hintedPositions.map(pos => game.word.toUpperCase()[pos]),
+            };
+        }
+
+        return {
+            hasPlayed: true,
+            gameId: game.id,
+            status: 'FINISHED',
+            attempts: game.player1Attempts,
+            winnerId: game.winnerId,
+        };
     }
 
     async startSoloGame(userId: string, length?: number) {


### PR DESCRIPTION
##Summary
- GET /games/daily/today — new protected endpoint returning whether the authenticated user has already played today's daily challenge, with full game state (attempts, hints used, hint data) for in-progress games and win/loss data for finished ones
- Daily mode UI — full DailyPage implementation reusing GameGrid, GameKeyboard, and GameHint; covers all phases: loading → start → playing → won/lost → already-played on return visit
- Share result — emoji grid copied to clipboard after finishing, persisted to localStorage so sharing survives a page refresh
- Countdown timer — live HH:MM:SS countdown to the next daily word (UTC midnight)

  Closes #15, closes #16