### PR TITLE
fix: remove prisma generated package.json from nest assets copy

### DIFF
--- a/wordev-api/nest-cli.json
+++ b/wordev-api/nest-cli.json
@@ -3,14 +3,6 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true,
-    "assets": [
-      {
-        "include": "../prisma/generated/package.json",
-        "outDir": "./dist/prisma",
-        "flat": false
-      }
-    ],
-    "watchAssets": true
+    "deleteOutDir": true
   }
 }


### PR DESCRIPTION
Copying prisma/generated/package.json (which contains {"type":"module"}) into dist/prisma/generated/ caused Node.js to treat the CommonJS-compiled Prisma client as an ES module, crashing on startup with:
  ReferenceError: exports is not defined in ES module scope

TypeScript still compiles prisma/generated/*.ts into dist/prisma/generated/ via import resolution, so the client is available at runtime without the copy.