### PR TITLE
fix: ensure prisma generate runs before every build

### DIFF
--- a/wordev-api/package.json
+++ b/wordev-api/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "prebuild": "prisma generate",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",


### PR DESCRIPTION
Adds a prebuild script so that prisma generate always runs automatically before nest build, regardless of the deployment platform's build command. This ensures prisma/generated/*.ts exist and are compiled as ESM by TypeScript, preventing a CJS/ESM type mismatch in the dist output.