### PR TITLE
fix: add railway.json to explicitly set build and start commands

### DIFF
--- a/wordev-api/railway.json
+++ b/wordev-api/railway.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "buildCommand": "npm ci && npm run build"
+  },
+  "deploy": {
+    "startCommand": "npm run start:prod"
+  }
+}


### PR DESCRIPTION
Ensures Railway always runs npm ci then npm run build (which triggers the prebuild hook: prisma generate then nest build). Without this, Railway auto-detects commands and may skip prisma generate, causing TypeScript to compile the Prisma client as CJS instead of ESM.